### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: Python CI
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/Youvasrisoleti/my-blog-practice/security/code-scanning/1](https://github.com/Youvasrisoleti/my-blog-practice/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify `contents: read`, which is sufficient for the current workflow since it only needs to read the repository contents to run tests. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
